### PR TITLE
glue: fix wrong service name on read-config helper

### DIFF
--- a/glue/bin/read-config
+++ b/glue/bin/read-config
@@ -41,7 +41,7 @@ else
   if [ "true" != "${influx_enabled}" ]; then
     snapctl unset influxdb.binding-openhab.enabled
     snapctl stop --disable ${SNAP_INSTANCE_NAME}.influxd
-    snapctl stop --disable ${SNAP_INSTANCE_NAME}.influxd-setup
+    snapctl stop --disable ${SNAP_INSTANCE_NAME}.influx-setup
   fi
 fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,7 +74,6 @@ apps:
         command-chain:
             - bin/read-config
         command: runtime/bin/karaf
-        adapter: none
         plugs:
             - home
             - network


### PR DESCRIPTION
Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>