### PR TITLE
snap: add mount/systenm-observe plugs for service and debuging apps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,6 +54,8 @@ apps:
             - home
             - network
             - network-bind
+            - mount-observe
+            - system-observe
             - serial-port
             - raw-usb
             - gpio
@@ -69,6 +71,8 @@ apps:
             - home
             - network
             - network-bind
+            - mount-observe
+            - system-observe
             - serial-port
             - raw-usb
             - gpio
@@ -84,6 +88,8 @@ apps:
             - home
             - network
             - network-bind
+            - mount-observe
+            - system-observe
             - serial-port
             - raw-usb
             - gpio


### PR DESCRIPTION
Address missing permissions for openHAB service to observe system

Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>

