### PR TITLE
Update snap package recipe

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -317,7 +317,7 @@ parts:
 
     influxdb:
         source: https://github.com/influxdata/influxdb.git
-        source-tag: v1.7.5
+        source-tag: v1.8.0
         build-snaps: ["go"]
         source-depth: 1
         plugin: python

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -173,7 +173,7 @@ apps:
 parts:
     openhab:
         # source only as trigger build whenever something changes in openHAB repo
-        source: https://github.com/openhab/openhab-distro.git
+        source: https://github.com/openhab/openhab-addons.git
         plugin: nil
         stage:
           - -start*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,6 +54,8 @@ apps:
             - home
             - network
             - network-bind
+            - mount-observe
+            - system-observe
             - serial-port
             - raw-usb
             - gpio
@@ -69,6 +71,8 @@ apps:
             - home
             - network
             - network-bind
+            - mount-observe
+            - system-observe
             - serial-port
             - raw-usb
             - gpio
@@ -84,6 +88,8 @@ apps:
             - home
             - network
             - network-bind
+            - mount-observe
+            - system-observe
             - serial-port
             - raw-usb
             - gpio

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -234,6 +234,7 @@ parts:
                 - libxau6:armhf
                 - libx11-6:armhf
                 - zip:armhf
+                - unzip:armhf
                 - jq:armhf
                 - libasound2:armhf
             - to arm64:
@@ -246,6 +247,7 @@ parts:
                 - libxau6:arm64
                 - libx11-6:arm64
                 - zip:arm64
+                - unzip:arm64
                 - jq:arm64
                 - libasound2:arm64
             - to i386:
@@ -258,6 +260,7 @@ parts:
                 - libxau6:i386
                 - libx11-6:i386
                 - zip:i386
+                - unzip:i386
                 - jq:i386
                 - libasound2:i386
             - to amd64:
@@ -270,6 +273,7 @@ parts:
                 - libxau6:amd64
                 - libx11-6:amd64
                 - zip:amd64
+                - unzip:amd64
                 - jq:amd64
                 - libasound2:amd64
 


### PR DESCRIPTION
- snap: move to influxd version 1.8.0
- snap: add source to openhab-addons serving as automated build trigger
- snap: add missing unzip dependency