### PR TITLE
Fix race conditions during install/refresh/uninstall

### DIFF
--- a/glue/bin/read-config
+++ b/glue/bin/read-config
@@ -24,24 +24,30 @@ else
     export HOST="$(echo ${url} | sed 's/:.*//')"
 fi
 
-# if there is influxdb.cfg file created,
-# automatically enable builtin influxdb integration
-if [ -f ${SNAP_DATA}/conf/services/influxdb.cfg ]; then
-  # if integration is disabled, do not auto enable it
-  influx_enabled=$(snapctl get influxdb.binding-openhab.enabled)
-  if [ "false" != "${influx_enabled}" ] || [ "true" != "${influx_enabled}" ]; then
-    # automatically disable builtin influxdb
-    snapctl set influxdb.binding-openhab.enabled="true"
-    snapctl start --enable ${SNAP_INSTANCE_NAME}.influxd
-    snapctl start --enable ${SNAP_INSTANCE_NAME}.influx-setup
-  fi
-else
-  # if persistent plugin was removed, no need to run influxdb anymore
-  influx_enabled=$(snapctl get influxdb.binding-openhab.enabled)
-  if [ "true" != "${influx_enabled}" ]; then
-    snapctl unset influxdb.binding-openhab.enabled
-    snapctl stop --disable ${SNAP_INSTANCE_NAME}.influxd
-    snapctl stop --disable ${SNAP_INSTANCE_NAME}.influx-setup
+# if openHAB is already running, then we are called as part of different action
+# do not check for influxdb service state
+if [ ! -f ${SNAP_DATA}/userdata/tmp/instances/instance.properties ] \
+   || [ "0" = "$( grep pid ${SNAP_DATA}/userdata/tmp/instances/instance.properties | awk '{print $3}')" ]; then
+  echo "openHAB is not running, check if influxdb should be started/stopped"
+  # if there is influxdb.cfg file created,
+  # automatically enable builtin influxdb integration
+  if [ -f ${SNAP_DATA}/conf/services/influxdb.cfg ]; then
+    # if integration is disabled, do not auto enable it
+    influx_enabled=$(snapctl get influxdb.binding-openhab.enabled)
+    if [ "false" != "${influx_enabled}" ] || [ "true" != "${influx_enabled}" ]; then
+      # automatically disable builtin influxdb
+      snapctl set influxdb.binding-openhab.enabled="true"
+      snapctl start --enable ${SNAP_INSTANCE_NAME}.influxd
+      snapctl start --enable ${SNAP_INSTANCE_NAME}.influx-setup
+    fi
+  else
+    # if persistent plugin was removed, no need to run influxdb anymore
+    influx_enabled=$(snapctl get influxdb.binding-openhab.enabled)
+    if [ "true" != "${influx_enabled}" ]; then
+      snapctl unset influxdb.binding-openhab.enabled
+      snapctl stop --disable ${SNAP_INSTANCE_NAME}.influxd
+      snapctl stop --disable ${SNAP_INSTANCE_NAME}.influx-setup
+    fi
   fi
 fi
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -5,6 +5,13 @@ set -x
 exec >> $SNAP_COMMON/hook.log 2>&1
 echo "$(date '+%Y-%m-%d %H:%M:%S') $0: Entering hook"
 
+# continue here only if openHAB is actually running
+if [ ! -f ${SNAP_DATA}/userdata/tmp/instances/instance.properties ] \
+   || [ "0" = "$( grep pid ${SNAP_DATA}/userdata/tmp/instances/instance.properties | awk '{print $3}')" ]; then
+    echo "Ignoring configure hook as openHAB service is not running to be restarted"
+    exit 0
+fi
+
 # check if we need to run influxdb
 if [ "true" == "$(snapctl get influxdb.binding-openhab.enabled)" ]; then
     snapctl start --enable ${SNAP_INSTANCE_NAME}.influxd


### PR DESCRIPTION
- configure hook is called during install and therefore restarting openhab service during install causes race condition as we are trying to restart services of snap which is not yet fully installed
- read-config helper is chain command, which is also used for stop command. Check for influxdb state only if openHAB service is not running and ignore check any other time