### PR TITLE
snap: add missing arping tool

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -225,6 +225,7 @@ parts:
         plugin: nil
         stage-packages:
             - to armhf:
+                - arping:armhf
                 - libxi6:armhf
                 - libxrender1:armhf
                 - libxtst6:armhf
@@ -238,6 +239,7 @@ parts:
                 - jq:armhf
                 - libasound2:armhf
             - to arm64:
+                - arping:arm64
                 - libxi6:arm64
                 - libxrender1:arm64
                 - libxtst6:arm64
@@ -251,6 +253,7 @@ parts:
                 - jq:arm64
                 - libasound2:arm64
             - to i386:
+                - arping:i386
                 - libxi6:i386
                 - libxrender1:i386
                 - libxtst6:i386
@@ -264,6 +267,7 @@ parts:
                 - jq:i386
                 - libasound2:i386
             - to amd64:
+                - arping:amd64
                 - libxi6:amd64
                 - libxrender1:amd64
                 - libxtst6:amd64


### PR DESCRIPTION
Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>