### PR TITLE
Adding support for openHAB 3.x

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,14 +1,11 @@
 #!/bin/bash
 
-set -x
+logger "$(date '+%Y-%m-%d %H:%M:%S'): Entering $(basename $0) hook"
 
-exec >> $SNAP_COMMON/hook.log 2>&1
-echo "$(date '+%Y-%m-%d %H:%M:%S') $0: Entering hook"
-
-# continue here only if openHAB is actually running
+# continue only if openHAB is running
 if [ ! -f ${SNAP_DATA}/userdata/tmp/instances/instance.properties ] \
    || [ "0" = "$( grep pid ${SNAP_DATA}/userdata/tmp/instances/instance.properties | awk '{print $3}')" ]; then
-    echo "Ignoring configure hook as openHAB service is not running to be restarted"
+    logger "Ignoring configure hook as openHAB service is not running to be restarted"
     exit 0
 fi
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-set -x
-
-exec >> $SNAP_COMMON/install.log 2>&1
-echo "$(date '+%Y-%m-%d %H:%M:%S') $0: Entering hook"
+logger "$(date '+%Y-%m-%d %H:%M:%S'): Entering $(basename $0) hook"
 
 # handle fresh istall
 cp -rf $SNAP/userdata $SNAP_DATA/

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,12 +1,9 @@
 #!/bin/bash
 
-set -x
-
 ## Clean log files first
 rm ${SNAP_DATA}/userdata/logs/*
-
-exec > "${SNAP_DATA}/userdata/logs/update.log" 2>&1
-echo "$(date '+%Y-%m-%d %H:%M:%S') $0: Entering hook"
+[ -e ${SNAP_COMMON}/hook.log ] && rm ${SNAP_COMMON}/hook.log
+logger "$(date '+%Y-%m-%d %H:%M:%S'): Entering $(basename $0) hook"
 
 # migrate snap configuration to new schema
 #    old key                new key
@@ -59,25 +56,25 @@ runCommand() {
     case $command in
     'DEFAULT')
       # Just rename the file, the update process adds back the new version
-      echo "  Adding '.bak' to $param1"
+      logger "  Adding '.bak' to $param1"
       mv "$param1" "$param1.bak"
     ;;
     'DELETE')
       # We should be strict and specific here, i.e only delete one file.
       if [ -f "$param1" ]; then
-        echo "  Deleting File: $param1"
+        logger "  Deleting File: $param1"
         rm -f "$param1"
       fi
     ;;
     'DELETEDIR')
       # We should be strict and specific here, i.e only delete one directory.
       if [ -d "$param1" ]; then
-        echo "  Deleting Directory: $param1"
+        logger "  Deleting Directory: $param1"
         rm -rf "$param1"
       fi
     ;;
     'MOVE')
-      echo "  Moving:   From $param1 to $param2"
+      logger "  Moving:   From $param1 to $param2"
       fileDir=$(dirname "$param2")
       # Create directory
       if [ ! -d fileDir ]; then
@@ -88,7 +85,7 @@ runCommand() {
     'REPLACE')
       # Avoid error if file does not exist
       if [ -f "$param3" ]; then
-        echo "  Replacing: String $param1 to $param2 in file $param3"
+        logger "  Replacing: String $param1 to $param2 in file $param3"
         sed -i'.bak' -e "s:$param1:$param2:g" "$param3"
       fi
     ;;
@@ -127,8 +124,7 @@ scanVersioningList() {
         LineVersionNumber=$(getVersionNumber "$LineVersion")
         if [ "$CurrentVersionNumber" -lt "$LineVersionNumber" ]; then
           InNewVersion=true
-          echo ""
-          echo "$VersionMessage $LineVersion:"
+          logger "$VersionMessage $LineVersion:"
         else
           InNewVersion=false
         fi
@@ -159,10 +155,7 @@ esac
 
 ## if current and new version are same, no need to do migration steps, it's security build
 if [ "$NewVersion" = "$CurrentVersion" ]; then
-  echo ""
-  echo "SUCCESS: openHAB version did not chnage( $CurrentVersion to $NewVersion)"
-  echo "This is security update"
-  echo ""
+  logger "SUCCESS: openHAB version did not chnage( $CurrentVersion to $NewVersion), This is security update"
   exit
 fi
 
@@ -179,7 +172,7 @@ else
   LegacyAddonsDownloadLocation="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F$NewVersion%2Fopenhab-addons-legacy-$NewVersion.kar"
 fi
 
-echo -e "Upgrading from version ${CurrentVersion} to ${NewVersion}"
+logger "Upgrading from version ${CurrentVersion} to ${NewVersion}"
 WorkingDir=${SNAP}
 
 ## Notify the user of important changes first
@@ -199,7 +192,7 @@ do
 done < "${SNAP}/runtime/bin/userdata_sysfiles.lst"
 
 ## Clearing the cache and tmp folders is necessary for upgrade.
-echo "Clearing cache..."
+logger "Clearing cache..."
 rm -rf "${SNAP_DATA}/userdata/cache"
 rm -rf "${SNAP_DATA}/userdata/tmp"
 
@@ -221,15 +214,13 @@ scanVersioningList "POST" "Performing post-update tasks for version"
 ## If there's an existing addons file, we need to replace it with the correct version.
 AddonsFile="${SNAP_DATA}/addons/openhab-addons-$CurrentVersion.kar"
 if [ -f "$AddonsFile" ] && [ -n "$AddonsDownloadLocation" ]; then
-  echo "Found an openHAB addons file, replacing with new version..."
+  logger "Found an openHAB addons file, replacing with new version..."
   rm -f "${AddonsFile:?}"
   curl -Lf# "$AddonsDownloadLocation" -o "${SNAP_DATA}/addons/openhab-addons-${NewVersion}}.kar" || {
-      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+      logger "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
   }
 fi
 
 # add here more custom migration steps
 
-echo ""
-echo "SUCCESS: openHAB updated from $CurrentVersion to $NewVersion"
-echo ""
+logger "SUCCESS: openHAB updated from $CurrentVersion to $NewVersion"

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -78,6 +78,11 @@ runCommand() {
     ;;
     'MOVE')
       echo "  Moving:   From $param1 to $param2"
+      fileDir=$(dirname "$param2")
+      # Create directory
+      if [ ! -d fileDir ]; then
+        mkdir -p "$fileDir"
+      fi
       mv "$param1" "$param2"
     ;;
     'REPLACE')
@@ -220,16 +225,6 @@ if [ -f "$AddonsFile" ] && [ -n "$AddonsDownloadLocation" ]; then
   rm -f "${AddonsFile:?}"
   curl -Lf# "$AddonsDownloadLocation" -o "${SNAP_DATA}/addons/openhab-addons-${NewVersion}}.kar" || {
       echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
-  }
-fi
-
-## Do the same for the legacy addons file.
-LegacyAddonsFile="${SNAP_DATA}/addons/openhab-addons-legacy-$CurrentVersion.kar"
-if [ -f "$LegacyAddonsFile" ] && [ -n "$LegacyAddonsDownloadLocation" ]; then
-  echo "Found an openHAB legacy addons file, replacing with new version..."
-  rm -f "${LegacyAddonsFile:?}"
-  curl -Lf# "$LegacyAddonsDownloadLocation" -o "${SNAP_DATA}/addons/openhab-addons-legacy-${NewVersion}.kar" || {
-      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
   }
 fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -287,13 +287,13 @@ parts:
         override-pull: |
           echo "SNAPCRAFT_ARCH_TRIPLET=${SNAPCRAFT_ARCH_TRIPLET}"
           if [ "${SNAPCRAFT_ARCH_TRIPLET}" = "arm-linux-gnueabihf" ]; then
-              curl -H "Accept: application/json" "https://api.azul.com/zulu/download/community/v1.0/bundles/?zulu_version=8&ext=tar.gz&os=linux&arch=arm&hw_bitness=32&bundle_type=jdk" | jq -c 'sort_by(.id) | .[] | select(.name | contains("aarch32hf"))' | jq -s '.[-1]' > ${SNAPCRAFT_PART_INSTALL}/zulu_version.json
+              curl -H "Accept: application/json" "https://api.azul.com/zulu/download/community/v1.0/bundles/?zulu_version=11&ext=tar.gz&os=linux&arch=arm&hw_bitness=32&bundle_type=jdk" | jq -c 'sort_by(.id) | .[] | select(.name | contains("aarch32hf"))' | jq -s '.[-1]' > ${SNAPCRAFT_PART_INSTALL}/zulu_version.json
           elif [ "${SNAPCRAFT_ARCH_TRIPLET}" = "aarch64-linux-gnu" ]; then
-              curl -H "Accept: application/json" "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?zulu_version=8&ext=tar.gz&os=linux&arch=arm&hw_bitness=64&bundle_type=jdk" | jq . > ${SNAPCRAFT_PART_INSTALL}/zulu_version.json
+              curl -H "Accept: application/json" "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?zulu_version=11&ext=tar.gz&os=linux&arch=arm&hw_bitness=64&bundle_type=jdk" | jq . > ${SNAPCRAFT_PART_INSTALL}/zulu_version.json
           elif [ "${SNAPCRAFT_ARCH_TRIPLET}" = "x86_64-linux-gnu" ]; then
-              curl -H "Accept: application/json" "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?zulu_version=8&ext=tar.gz&os=linux&arch=x86&hw_bitness=64&bundle_type=jdk" | jq . > ${SNAPCRAFT_PART_INSTALL}/zulu_version.json
+              curl -H "Accept: application/json" "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?zulu_version=11&ext=tar.gz&os=linux&arch=x86&hw_bitness=64&bundle_type=jdk" | jq . > ${SNAPCRAFT_PART_INSTALL}/zulu_version.json
           else
-              curl -H "Accept: application/json" "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?zulu_version=8&ext=tar.gz&os=linux&arch=x86&hw_bitness=32&bundle_type=jdk" | jq . > ${SNAPCRAFT_PART_INSTALL}/zulu_version.json
+              curl -H "Accept: application/json" "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?zulu_version=11&ext=tar.gz&os=linux&arch=x86&hw_bitness=32&bundle_type=jdk" | jq . > ${SNAPCRAFT_PART_INSTALL}/zulu_version.json
           fi
           tar_link=$(jq -r '.url' ${SNAPCRAFT_PART_INSTALL}/zulu_version.json)
           echo "tar_link=[${tar_link}]"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -299,17 +299,15 @@ parts:
           echo "tar_link=[${tar_link}]"
           wget -O zulu.tar.gz ${tar_link}
           tar -C ${SNAPCRAFT_PART_INSTALL} -xf zulu.tar.gz --strip 1
-        stage:
-          - -bin
-          - -demo
-          - -include
-          - -lib
-          - -man
-          - -sample
-          - -src.zip
-          - -openjfx-src.zip
-          - -jre/lib/aarch32/client/libjvm.diz
-          - -jre/lib/aarch64/server/libjvm.diz
+          rm -rf ${SNAPCRAFT_PART_INSTALL}/demo \
+                 ${SNAPCRAFT_PART_INSTALL}/include \
+                 ${SNAPCRAFT_PART_INSTALL}/jmods \
+                 ${SNAPCRAFT_PART_INSTALL}/legal \
+                 ${SNAPCRAFT_PART_INSTALL}/lib/ct.sym \
+                 ${SNAPCRAFT_PART_INSTALL}/lib/libattach.so \
+                 ${SNAPCRAFT_PART_INSTALL}/lib/libsaproc.so \
+                 ${SNAPCRAFT_PART_INSTALL}/lib/src.zip \
+                 ${SNAPCRAFT_PART_INSTALL}/man
         organize:
           LICENSE: LICENSE_ZULU
           release: release_zulu

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -195,19 +195,27 @@ parts:
                     break
                 fi
             done
-            wget --quiet -O latest_version https://bintray.com/openhab/mvn/openhab-distro/_latestVersion
-            latest_version="$(grep \'version\': latest_version | awk '{print $2}' | sed -e "s/'//g" -e 's/,//g')"
-            latest_milestone_version=$(curl --silent -q https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/maven-metadata.xml | grep "<version>" | tail -1 | sed 's/.*>\(.*\)<.*/\1/g')
+            wget --quiet -O latest_version https://bintray.com/openhab/mvn/openhab-core/_latestVersion
+            latest_version="$(grep \'version\': latest_version | \
+                              awk '{print $2}' | \
+                              sed -e "s/'//g" -e 's/,//g')"
+            milestone_version="$( \
+                  curl --silent -q \
+                  https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/maven-metadata.xml \
+                  | grep "<version>" \
+                  | tail -1 \
+                  | sed 's/.*>\(.*\)<.*/\1/g')"
+
             # first we check for milestone in candidate, then if we have latest release version in beta
             echo "last_released_tag=${last_released_tag}, last_candidate_tag=${last_candidate_tag}, " \
-                 "latest_version=${latest_version}, latest_milestone_version=${latest_milestone_version}"
+                 "latest_version=${latest_version}, milestone_version=${milestone_version}"
             # compare main version of milestore release to candidate version e.g. 3.0.0.RC2 -> 3.0.0,
             # since 3.0.0.RC2 is otherwise consideted as newer then final 3.0.0, which would be wrong
-            if $(dpkg --compare-versions "${last_candidate_tag}" "lt" "$(echo ${latest_milestone_version}| cut -c -5)"); then
-               echo "Building latest milestone version: ${latest_milestone_version}"
+            if $(dpkg --compare-versions "${last_candidate_tag}" "lt" "$(echo ${milestone_version}| cut -c -5)"); then
+               echo "Building latest milestone version: ${milestone_version}"
                wget --quiet \
                     -O openhab-milestone.tar.gz \
-                    https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/${latest_milestone_version}/openhab-${latest_milestone_version}.tar.gz
+                    https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/${milestone_version}/openhab-${milestone_version}.tar.gz
             elif [ "${latest_version}" != "${last_released_tag}" ]; then
                echo "Building latest release version: ${latest_version}"
                wget --quiet \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -199,7 +199,11 @@ parts:
             latest_version="$(grep \'version\': latest_version | awk '{print $2}' | sed -e "s/'//g" -e 's/,//g')"
             latest_milestone_version=$(curl --silent -q https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/maven-metadata.xml | grep "<version>" | tail -1 | sed 's/.*>\(.*\)<.*/\1/g')
             # first we check for milestone in candidate, then if we have latest release version in beta
-            if $(dpkg --compare-versions "${last_candidate_tag}" "lt" "${latest_milestone_version}"); then
+            echo "last_released_tag=${last_released_tag}, last_candidate_tag=${last_candidate_tag}, " \
+                 "latest_version=${latest_version}, latest_milestone_version=${latest_milestone_version}"
+            # compare main version of milestore release to candidate version e.g. 3.0.0.RC2 -> 3.0.0,
+            # since 3.0.0.RC2 is otherwise consideted as newer then final 3.0.0, which would be wrong
+            if $(dpkg --compare-versions "${last_candidate_tag}" "lt" "$(echo ${latest_milestone_version}| cut -c -5)"); then
                echo "Building latest milestone version: ${latest_milestone_version}"
                wget --quiet \
                     -O openhab-milestone.tar.gz \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -217,7 +217,7 @@ parts:
                echo "Building latest snapshot version"
                wget --quiet \
                     -O openhab.zip \
-                    https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/*zip*/target.zip
+                    https://ci.openhab.org/job/openHAB3-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/*zip*/target.zip
                unzip openhab.zip
                rm openhab.zip
                mv target/openhab-*.tar.gz .

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -182,7 +182,13 @@ parts:
           LICENSE: LICENSE_OPENHAB
         override-pull: |
             last_released_tag="$(snap info openhab | awk '$1 == "latest/beta:" { print $2 }')"
-            last_candidate_tag="$(snap info openhab | awk '$1 == "latest/candidate:" { print $2 }')"
+            # if candidate is close, go to beta -> edge
+            for ch in "candidate" "beta" "edge"; do
+                last_candidate_tag="$(snap info ${SNAPCRAFT_PROJECT_NAME} | grep "latest/${ch}" | awk '{ print $2 }')"
+                if [ -n "${last_candidate_tag}" ] && [ ! "${last_candidate_tag}" = "^" ]; then
+                    break
+                fi
+            done
             wget --quiet -O latest_version https://bintray.com/openhab/mvn/openhab-distro/_latestVersion
             latest_version="$(grep \'version\': latest_version | awk '{print $2}' | sed -e "s/'//g" -e 's/,//g')"
             latest_milestone_version=$(curl --silent -q https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/maven-metadata.xml | grep "<version>" | tail -1 | sed 's/.*>\(.*\)<.*/\1/g')

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,8 +24,8 @@ architectures:
     - build-on: i386
 
 environment:
-    JAVA_HOME:        ${SNAP}/jre
-    PATH:             ${SNAP}/jre/bin:${SNAP}/usr/sbin:${SNAP}/usr/bin:${SNAP}/sbin:${SNAP}/bin:${PATH}
+    JAVA_HOME:        ${SNAP}
+    PATH:             ${SNAP}/usr/sbin:${SNAP}/usr/bin:${SNAP}/sbin:${SNAP}/bin:${PATH}
     LD_LIBRARY_PATH:  ${SNAP_LIBRARY_PATH}:${LD_LIBRARY_PATH}:${SNAP}/lib:${SNAP}/usr/lib:${SNAP}/lib/${SNAPCRAFT_ARCH_TRIPLET}:${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}
     OPENHAB_CONF:     ${SNAP_DATA}/conf
     OPENHAB_RUNTIME:  ${SNAP}/runtime

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -181,7 +181,13 @@ parts:
         organize:
           LICENSE: LICENSE_OPENHAB
         override-pull: |
-            last_released_tag="$(snap info openhab | awk '$1 == "latest/beta:" { print $2 }')"
+            # if beta is closed, check edge
+            for ch in "beta" "edge"; do
+                last_released_tag="$(snap info ${SNAPCRAFT_PROJECT_NAME} | grep "latest/${ch}" | awk '{ print $2 }')"
+                if [ -n "${last_released_tag}" ] && [ ! "${last_released_tag}" = "^" ]; then
+                    break
+                fi
+            done
             # if candidate is close, go to beta -> edge
             for ch in "candidate" "beta" "edge"; do
                 last_candidate_tag="$(snap info ${SNAPCRAFT_PROJECT_NAME} | grep "latest/${ch}" | awk '{ print $2 }')"


### PR DESCRIPTION
Cumulative changes adding support for openHAB 3.x builds

- automatically pick correct build based on released versions in the channels
  - If there is a new stable version than in the stable channel, new stable version is built
  - if there is a new milestone version available, newer than the stable channel version, or newer than existing milestone version in the candidate channel, new milestone version is built
  - if beta channel is closed, last stable version is rebuilt, even if there is already same version in the stable channel
    - this is to allow security rebuilds if dependencies have security fixes needed to be pulled in, e.g. new version of java runtime
  - if none of the conditions is met, snapshot build is made into the edge channel

Update `post-refresh` hook with changes from 3.x release
Fixes to the urls related to changes introduced by version 3.x
Fixes to java part, to make it more robust