### PR TITLE
snap: jre: remove potential 's' file mode

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -287,6 +287,8 @@ parts:
                  ${SNAPCRAFT_PART_INSTALL}/lib/src.zip \
                  ${SNAPCRAFT_PART_INSTALL}/man
           cp ${SNAPCRAFT_PART_BUILD}/zulu_version.json ${SNAPCRAFT_PART_INSTALL}/zulu_version.json
+          # remove potential 's' file mode
+          chmod -s -R ${SNAPCRAFT_PART_INSTALL}/*
         organize:
           LICENSE: LICENSE_ZULU
           release: release_zulu


### PR DESCRIPTION
32 bit arm version of Zulu seems to have an additional 's' file mode set, this is unnecessary, and it breaks snap auto review.

Make this file parameters are removed at the build time, to pass auto review.
