### PR TITLE
Move to base: core24

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Use this method when snapcraft cannot manage containers (e.g., inside existing c
 
 **Notes:**
 - **Method 1**: Snapcraft manages containers automatically, provides cleaner isolation
-- **Method 2**: Required when LXC nesting is unavailable or snapcraft lacks container privileges  
+- **Method 2**: Required when LXC nesting is unavailable or snapcraft lacks container privileges
 - Use `--destructive-mode` only when snapcraft cannot create its own build environment
 - The `--dangerous` flag is needed because the snap is not from the official store
 - For different architectures, adapt the image tag (e.g., `ubuntu:22.04/amd64`) and use the appropriate platform, cross-compilation is not supported with snapcraft.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,12 +15,12 @@ description: |
 confinement: strict
 grade: stable
 adopt-info: openhab
-base: core22
+base: core24
 
-architectures:
-    - build-on: armhf
-    - build-on: arm64
-    - build-on: amd64
+platforms:
+    armhf:
+    arm64:
+    amd64:
 
 environment:
     JAVA_HOME:        ${SNAP}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -184,7 +184,7 @@ parts:
             wget -O milestone-metadata.xml \
                  https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/maven-metadata.xml
             milestone_version="$(xmllint --xpath "string(//release)" milestone-metadata.xml)"
-            release_version="$(xmllint --xpath "string(//release)" release-metadata.xml)"
+            release_version="$(xmllint --xpath "string(//latest)" release-metadata.xml)"
             # first we check for milestone in candidate, then if we have latest release version in beta
             echo "stable_version=${stable_version}, candidate_version=${candidate_version}, " \
                  "beta_version=${beta_version}, release_version=${release_version}, milestone_version=${milestone_version}"


### PR DESCRIPTION
Cummulative changes
- move to base: core24
- resolve build blocked at 5.0.0.RC1 (metadata reports 4.37 as the latest -> use "release" version from metadata
- remo white space from README