### PR TITLE
snap: fix the snap name after accidental change

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: openhab-ondra
+name: openhab
 summary: openHAB smart home server
 description: |
  openHAB - a vendor and technology agnostic open source automation software for your home.


### PR DESCRIPTION
Fix accidentally changed the snap name